### PR TITLE
Add log statments to start and end of server

### DIFF
--- a/src/ls_server.rs
+++ b/src/ls_server.rs
@@ -346,7 +346,7 @@ impl Logger {
         let mut log_file = self.log_file.lock().unwrap();
         // FIXME(#40) write thread id to log_file
         log_file.write_all(s.as_bytes()).unwrap();
-        // writeln!(::std::io::stderr(), "{}", msg);
+        // writeln!(::std::io::stderr(), "{}", s);
     }
 }
 
@@ -375,6 +375,11 @@ impl MessageReader for StdioMsgReader {
         // Read in the "Content-length: xx" part
         let mut buffer = String::new();
         handle_err!(io::stdin().read_line(&mut buffer), "Could not read from stdin");
+
+        if buffer.len() == 0 {
+            self.logger.log("Header is empty");
+            return None;
+        }
 
         let res: Vec<&str> = buffer.split(" ").collect();
 
@@ -479,11 +484,13 @@ impl Output for StdioOutput {
 
 pub fn run_server(analysis: Arc<AnalysisHost>, vfs: Arc<Vfs>, build_queue: Arc<BuildQueue>) {
     let logger = Arc::new(Logger::new());
+    logger.log(&format!("\nLanguage Server Starting up\n"));
     let service = LsService::new(analysis,
                                  vfs,
                                  build_queue,
                                  Box::new(StdioMsgReader { logger: logger.clone() }),
                                  Box::new(StdioOutput { logger: logger.clone() } ),
-                                 logger);
+                                 logger.clone());
     LsService::run(service);
+    logger.log(&format!("\nServer shutting down.\n"));
 }


### PR DESCRIPTION
Also check for empty headers, which didn't have their own clause before.

These changes are mostly quality of life when trying to debug a new
client implementation, and `tail -f`-ing the log file.

This also pulls in a dependancy on the time crate, which is only
used for the pretty timestamps, which are not very important.