### PR TITLE
Added support for request Id to be either number or string as specifi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,14 @@ Use `cargo build` to build.
 
 ## Running
 
-To run the RLS, you need to specify the sysroot as an environment variable (this
+To run the RLS, you need to specify the SYS_ROOT as an environment variable (this
 should become unnecessary in the future). This is the route directory of your
 Rust installation. You can find the sysroot with `rustc --print sysroot`.
-
-If you have installed Rust directly it will probably be `/usr/local`; if you are using
-a home-made compiler, it will be something like `~/rust/x86_64-unknown-linux-gnu/stage2`;
-with Rustup it will change depending on the version of Rust being used, it
-should be something like `~/multirust/toolchain/nightly-x86_64-unknown-linux-gnu`.
 
 Run with:
 
 ```
-SYS_ROOT=/usr/local cargo run
+SYS_ROOT=$(rustc --print sysroot) cargo run
 ```
 
 To work with the RLS, your project must be buildable using `cargo build`. If you
@@ -84,7 +79,7 @@ things may still work a bit better, and debugging can be easier.
 To use the http protocol you need to run the RLS yourself as described above, with the `--http` parameter.
 
 ```
-SYS_ROOT=/usr/local cargo run -- --http
+SYS_ROOT=$(rustc --print sysroot) cargo run -- --http
 ```
 
 Then you can just open the extension in VSCode and run it (F5).

--- a/src/actions_ls.rs
+++ b/src/actions_ls.rs
@@ -185,7 +185,7 @@ impl ActionHandler {
         }
     }
 
-    pub fn symbols(&self, id: usize, doc: DocumentSymbolParams, out: &Output) {
+    pub fn symbols(&self, id: Id, doc: DocumentSymbolParams, out: &Output) {
         let t = thread::current();
         let analysis = self.analysis.clone();
     
@@ -209,7 +209,7 @@ impl ActionHandler {
         out.success(id, ResponseData::SymbolInfo(result));
     }
 
-    pub fn complete(&self, id: usize, params: TextDocumentPositionParams, out: &Output) {
+    pub fn complete(&self, id: Id, params: TextDocumentPositionParams, out: &Output) {
         let vfs: &Vfs = &self.vfs;
         let result: Vec<CompletionItem> = panic::catch_unwind(move || {
             let pos = adjust_vscode_pos_for_racer(params.position);
@@ -235,7 +235,7 @@ impl ActionHandler {
         out.success(id, ResponseData::CompletionItems(result));
     }
 
-    pub fn rename(&self, id: usize, params: RenameParams, out: &Output) {
+    pub fn rename(&self, id: Id, params: RenameParams, out: &Output) {
         let t = thread::current();
         let span = self.convert_pos_to_span(&params.textDocument, &params.position);
         let analysis = self.analysis.clone();
@@ -264,7 +264,7 @@ impl ActionHandler {
         out.success(id, ResponseData::WorkspaceEdit(WorkspaceEdit { changes: edits }));
     }
 
-    pub fn find_all_refs(&self, id: usize, params: ReferenceParams, out: &Output) {
+    pub fn find_all_refs(&self, id: Id, params: ReferenceParams, out: &Output) {
         let t = thread::current();
         let span = self.convert_pos_to_span(&params.textDocument, &params.position);
         let analysis = self.analysis.clone();
@@ -284,7 +284,7 @@ impl ActionHandler {
         out.success(id, ResponseData::Locations(refs));
     }
 
-    pub fn goto_def(&self, id: usize, params: TextDocumentPositionParams, out: &Output) {
+    pub fn goto_def(&self, id: Id, params: TextDocumentPositionParams, out: &Output) {
         // Save-analysis thread.
         let t = thread::current();
         let span = self.convert_pos_to_span(&params.textDocument, &params.position);
@@ -356,7 +356,7 @@ impl ActionHandler {
         }
     }
 
-    pub fn hover(&self, id: usize, params: HoverParams, out: &Output) {
+    pub fn hover(&self, id: Id, params: HoverParams, out: &Output) {
         let t = thread::current();
         let span = self.convert_pos_to_span(&params.textDocument, &params.position);
 
@@ -397,7 +397,7 @@ impl ActionHandler {
         }
     }
 
-    pub fn reformat(&self, id: usize, doc: TextDocumentIdentifier, out: &Output) {
+    pub fn reformat(&self, id: Id, doc: TextDocumentIdentifier, out: &Output) {
         self.logger.log(&format!("Reformat: {} {:?}\n", id, doc));
 
         let path = &Path::new(doc.file_name());


### PR DESCRIPTION
This addresses the need to support the id as both a number and a string as identified in - https://github.com/jonathandturner/rustls/issues/62.

I am opening the PR to see if this is the approach you would like to take. If you agree, I would like to do more manual testing to make sure this did not break anything prior to merge.