### PR TITLE
Reply with error for malformed input

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -244,7 +244,10 @@ impl LsService {
     pub fn handle_message(this: Arc<Self>) -> ServerStateChange {
         let c = match this.msg_reader.read_message() {
             Some(c) => c,
-            None => return ServerStateChange::Break,
+            None => {
+                this.output.parse_error();
+                return ServerStateChange::Break
+            },
         };
 
         let this = this.clone();
@@ -414,6 +417,10 @@ impl MessageReader for StdioMsgReader {
 
 pub trait Output {
     fn response(&self, output: String);
+
+    fn parse_error(&self) {
+        self.response(r#"{"jsonrpc": "2.0", "error": {"code": -32700, "message": "Parse error"}, "id": null}"#.to_owned());
+    }
 
     fn failure(&self, id: usize, message: &str) {
         // For now this is a catch-all for any error back to the consumer of the RLS

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -111,6 +111,32 @@ fn test_simple_goto_def() {
     expect_messages(results.clone(), &[ExpectedMessage::new(Some(42)).expect_contains("\"start\":{\"line\":11,\"character\":8}")]);
 }
 
+
+#[test]
+fn test_parse_error_on_malformed_input() {
+    struct NoneMsgReader;
+
+    impl ls_server::MessageReader for NoneMsgReader {
+        fn read_message(&self) -> Option<String> { None }
+    }
+
+    let analysis = Arc::new(analysis::AnalysisHost::new(analysis::Target::Debug));
+    let vfs = Arc::new(vfs::Vfs::new());
+    let build_queue = Arc::new(build::BuildQueue::new(vfs.clone()));
+    let reader = Box::new(NoneMsgReader);
+    let output = Box::new(RecordOutput::new());
+    let results = output.output.clone();
+    let logger = Arc::new(ls_server::Logger::new());
+    let server = ls_server::LsService::new(analysis, vfs, build_queue, reader, output, logger);
+
+    assert_eq!(ls_server::LsService::handle_message(server.clone()),
+               ls_server::ServerStateChange::Break);
+
+    let error = results.lock().unwrap()
+        .pop().expect("no error response");
+    assert!(error.contains(r#""code": -32700"#))
+}
+
 /*
 // Initialise and run the internals of an RLS server.
 fn mock_server<F>(f: F)


### PR DESCRIPTION
Let's produce an error response for a malformed input, instead of silently terminating. 

