### PR TITLE
Remove dead code

### DIFF
--- a/src/ide.rs
+++ b/src/ide.rs
@@ -12,8 +12,6 @@ use std::path::PathBuf;
 
 use analysis::{raw, Span};
 
-use vfs::Change;
-
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Position {
     pub filepath: PathBuf,
@@ -37,12 +35,6 @@ pub struct Input {
 pub enum Output {
     Ok(Position, Provider),
     Err,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ChangeInput {
-    pub project_path: PathBuf,
-    pub changes: Vec<Change>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This enables to remove `serde` from the dependencies of the rls-vfs, which I believe is the right thing to do (https://github.com/nrc/rls-vfs/pull/6). Not sure what this struct was intended for though, so I may be doing something stupid :)  