### PR TITLE
Make document links clickable

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -385,7 +385,7 @@ impl ActionHandler {
                 contents.push(MarkedString::from_markdown(docs.into()));
             }
             if !doc_url.is_empty() {
-                contents.push(MarkedString::from_language_code("url".into(), doc_url.into()));
+                contents.push(MarkedString::from_markdown(doc_url.into()));
             }
             if !ty.is_empty() {
                 contents.push(MarkedString::from_language_code("rust".into(), ty.into()));


### PR DESCRIPTION
A URL will be auto-linked in a markdown text. Therefore, marking the URL
as markdown instead of being the language `url` makes the link
clickable.

Solves jonathandturner/rls_vscode#17