### PR TITLE
FIX range calculation for reformatting

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -173,7 +173,7 @@ impl ActionHandler {
             let range = i.range.unwrap_or_else(|| {
                 // In this case the range is considered to be the whole document,
                 // as specified by LSP
-                ls_util::range_from_vfs_file(&self.vfs, &fname).unwrap()
+                ls_util::range_from_vfs_file(&self.vfs, &fname)
             });
             let range = ls_util::range_to_rls(range);
             Change {
@@ -437,7 +437,7 @@ impl ActionHandler {
             Ok(_) => {
                 // Note that we don't need to keep the VFS up to date, the client
                 // echos back the change to us.
-                let range = ls_util::range_from_vfs_file(&self.vfs, &path).unwrap();
+                let range = ls_util::range_from_vfs_file(&self.vfs, &path);
                 let text = String::from_utf8(buf).unwrap();
                 let result = [TextEdit {
                     range: range,

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -173,7 +173,7 @@ impl ActionHandler {
             let range = i.range.unwrap_or_else(|| {
                 // In this case the range is considered to be the whole document,
                 // as specified by LSP
-                ls_util::range_from_vfs_file(&self.vfs, &fname)
+                ls_util::range_from_vfs_file(&self.vfs, &fname).unwrap()
             });
             let range = ls_util::range_to_rls(range);
             Change {
@@ -437,12 +437,10 @@ impl ActionHandler {
             Ok(_) => {
                 // Note that we don't need to keep the VFS up to date, the client
                 // echos back the change to us.
+                let range = ls_util::range_from_vfs_file(&self.vfs, &path).unwrap();
                 let text = String::from_utf8(buf).unwrap();
                 let result = [TextEdit {
-                    range: Range {
-                        start: Position::new(0, 0),
-                        end: Position::new(text.lines().count() as u64, 0),
-                    },
+                    range: range,
                     new_text: text,
                 }];
                 out.success(id, ResponseData::TextEdit(result))

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -16,7 +16,6 @@ use analysis::raw;
 use hyper::Url;
 use serde::Serialize;
 use span;
-use vfs;
 
 pub use ls_types::*;
 
@@ -86,17 +85,20 @@ pub mod ls_util {
         }
     }
 
-    pub fn range_from_vfs_file(_vfs: &Vfs, _fname: &Path) -> Result<Range, vfs::Error> {
-        let content = _vfs.load_file(_fname)?;
+    /// Creates a `Range` spanning the whole file as currently known by `Vfs`
+    ///
+    /// Panics if `Vfs` cannot load the file.
+    pub fn range_from_vfs_file(vfs: &Vfs, fname: &Path) -> Range {
+        let content = vfs.load_file(fname).unwrap();
         if content.is_empty() {
-            Ok(Range {start: Position::new(0, 0), end: Position::new(0, 0)})
+            Range {start: Position::new(0, 0), end: Position::new(0, 0)}
         } else {
             // range is zero-based and the end position is exclusive
-            Ok(Range {
+            Range {
                 start: Position::new(0, 0),
                 end: Position::new(content.lines().count() as u64 - 1,
                         content.lines().last().expect("String is not empty.").chars().count() as u64)
-            })
+            }
         }
     }
 }

--- a/src/lsp_data.rs
+++ b/src/lsp_data.rs
@@ -16,6 +16,7 @@ use analysis::raw;
 use hyper::Url;
 use serde::Serialize;
 use span;
+use vfs;
 
 pub use ls_types::*;
 
@@ -85,11 +86,18 @@ pub mod ls_util {
         }
     }
 
-    pub fn range_from_vfs_file(_vfs: &Vfs, _fname: &Path) -> Range {
-        // FIXME: todo, endpos must be the end of the document, this is not correct
-
-        let end_pos = Position::new(0, 0);
-        Range{ start: Position::new(0, 0), end: end_pos }
+    pub fn range_from_vfs_file(_vfs: &Vfs, _fname: &Path) -> Result<Range, vfs::Error> {
+        let content = _vfs.load_file(_fname)?;
+        if content.is_empty() {
+            Ok(Range {start: Position::new(0, 0), end: Position::new(0, 0)})
+        } else {
+            // range is zero-based and the end position is exclusive
+            Ok(Range {
+                start: Position::new(0, 0),
+                end: Position::new(content.lines().count() as u64 - 1,
+                        content.lines().last().expect("String is not empty.").chars().count() as u64)
+            })
+        }
     }
 }
 


### PR DESCRIPTION
Reformatting this snippet triggers a `TypeError: Cannot read property 'substring' of null` for me.

```rust
fn main() {println!("Hello World")}
fn unused() {unreachable!()}
```

I fixed this by fixing `range_from_vfs_file` and using it to calculate the span to replace.